### PR TITLE
apply changes based on feedback

### DIFF
--- a/src/main/java/report/processor/impl/ExecutorReportProcessor.java
+++ b/src/main/java/report/processor/impl/ExecutorReportProcessor.java
@@ -44,8 +44,9 @@ public class ExecutorReportProcessor implements ReportProcessor {
 
     /**
      * Create a new {@code ExecutorReportProcessor}.
-     * @param fileSystemHelper a helper object to get file information from the file system
-     * @param filePathFilter a filter ho monitor only changes in certain files, for example, XML files
+     *
+     * @param fileSystemHelper           a helper object to get file information from the file system
+     * @param filePathFilter             a filter ho monitor only changes in certain files, for example, XML files
      * @param fileMonitoringPeriodMillis delay in milliseconds to scan for file changes
      */
     public ExecutorReportProcessor(FileSystemHelper fileSystemHelper, Predicate<Path> filePathFilter, long fileMonitoringPeriodMillis) {
@@ -151,19 +152,17 @@ public class ExecutorReportProcessor implements ReportProcessor {
         return terminated;
     }
 
-    private Collection<ReportHandlerWrapper> handlersForReportType(String reportType) {
-        return handlers.values().stream().filter(hw -> hw.handlesReportType(reportType)).toList();
+    private Collection<ReportHandlerWrapper> handlersForReportTypes(Collection<String> reportTypes) {
+        return handlers.values().stream().filter(hw -> reportTypes.stream().anyMatch(hw::handlesReportType)).toList();
     }
 
     private void submitFileChanges(MonitoredFolder monitoredFolder) {
         var fileInfos = monitoredFolder.getNewMonitoredChanges(fileSystemHelper);
         var reportTypes = monitoredFolder.getReportTypes();
-        for (var reportType : reportTypes) {
-            var handlers = handlersForReportType(reportType);
-            for (var fileInfo : fileInfos) {
-                for (var handler : handlers) {
-                    fileHandlerService.submit(() -> handler.handle(fileInfo));
-                }
+        var handlers = handlersForReportTypes(reportTypes);
+        for (var fileInfo : fileInfos) {
+            for (var handler : handlers) {
+                fileHandlerService.submit(() -> handler.handle(fileInfo));
             }
         }
     }

--- a/src/main/java/report/processor/impl/FileSystemHelper.java
+++ b/src/main/java/report/processor/impl/FileSystemHelper.java
@@ -4,6 +4,7 @@ import report.processor.FileInfo;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Gets file information from the file system
@@ -12,8 +13,9 @@ interface FileSystemHelper {
     /**
      * Get file information for all the files in a folder.
      *
-     * @param folder folder
+     * @param folder         folder
+     * @param filePathFilter filter to get file information only for certain files, for example, XML
      * @return file information for all the files in the folder
      */
-    Collection<FileInfo> getFileInfos(Path folder);
+    Collection<FileInfo> getFileInfos(Path folder, Predicate<Path> filePathFilter);
 }

--- a/src/main/java/report/processor/impl/MonitoredFolder.java
+++ b/src/main/java/report/processor/impl/MonitoredFolder.java
@@ -96,7 +96,7 @@ class MonitoredFolder {
      */
     public Collection<FileInfo> getNewMonitoredChanges(FileSystemHelper fileSystemHelper) {
         var monitoredChanges = new ArrayList<FileInfo>();
-        var newFileInfos = fileSystemHelper.getFileInfos(folderPath);
+        var newFileInfos = fileSystemHelper.getFileInfos(folderPath, filePathFilter);
         var newFileInfosMap = new HashMap<Path, FileInfo>();
         for (var newFileInfo : newFileInfos) {
             if (filePathFilter.test(newFileInfo.filePath())) {

--- a/src/main/java/report/processor/impl/NioFileSystemHelper.java
+++ b/src/main/java/report/processor/impl/NioFileSystemHelper.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -17,13 +18,14 @@ import java.util.stream.Stream;
 public class NioFileSystemHelper implements FileSystemHelper {
     private static final Logger logger = Logger.getLogger(NioFileSystemHelper.class.getName());
 
-    public Collection<FileInfo> getFileInfos(Path folder) {
+    public Collection<FileInfo> getFileInfos(Path folder, Predicate<Path> filePathFilter) {
         var fileInfos = new ArrayList<FileInfo>();
         try {
             if (Files.exists(folder)) {
                 try (Stream<Path> files = Files.list(folder)) {
                     files
                             .filter(filePath -> !Files.isDirectory(filePath))
+                            .filter(filePathFilter)
                             .forEach(filePath -> {
                                 try {
                                     var attr = Files.readAttributes(filePath, BasicFileAttributes.class);

--- a/src/test/java/report/processor/impl/NioFileSystemHelperUnitTests.java
+++ b/src/test/java/report/processor/impl/NioFileSystemHelperUnitTests.java
@@ -3,25 +3,25 @@ package report.processor.impl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import report.processor.impl.FileSystemHelper;
-import report.processor.impl.NioFileSystemHelper;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.util.UUID;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static report.processor.util.TestUtils.TEMP_FOLDER;
 import static report.processor.util.TestUtils.createFile;
 import static report.processor.util.TestUtils.createFolder;
 import static report.processor.util.TestUtils.deleteFolder;
+import static report.processor.util.TestUtils.filePath;
+import static report.processor.util.TestUtils.filePathNonXml;
+import static report.processor.util.TestUtils.folderPath;
 import static report.processor.util.TestUtils.modifyFile;
 
 public class NioFileSystemHelperUnitTests {
-    private static final Path testFolder = TEMP_FOLDER.resolve(UUID.randomUUID().toString());
+    private static final Path testFolder = folderPath();
 
     @BeforeAll
     public static void setUp() {
@@ -33,18 +33,6 @@ public class NioFileSystemHelperUnitTests {
         deleteFolder(testFolder);
     }
 
-    private Path folderPath() {
-        return testFolder.resolve(UUID.randomUUID().toString());
-    }
-
-    private Path filePath(Path folderPath) {
-        return folderPath.resolve(UUID.randomUUID() + ".xml");
-    }
-
-    private Path filePath(Path folderPath, String fileName) {
-        return folderPath.resolve(fileName + ".xml");
-    }
-
     private String fileContent() {
         return "<?xml version=\"1.0\"?><report></report>";
     }
@@ -53,8 +41,12 @@ public class NioFileSystemHelperUnitTests {
         return "<?xml version=\"1.0\"?><report2></report2>";
     }
 
-    private FileSystemHelper fileInfoProvider() {
+    private FileSystemHelper fileSystemHelper() {
         return new NioFileSystemHelper();
+    }
+
+    private Predicate<Path> xmlPathPredicate() {
+        return filePath -> filePath.toString().toLowerCase().endsWith(".xml");
     }
 
     private FileTime getFileCreationTime(Path path) {
@@ -76,12 +68,12 @@ public class NioFileSystemHelperUnitTests {
     }
 
     @Test
-    public void givenProvider_whenCreateFile_thenGetFileInfo() throws InterruptedException {
+    public void givenFileSystemHelper_whenCreateFile_thenGetFileInfo() throws InterruptedException {
         // given
-        var folderPath = folderPath();
+        var folderPath = folderPath(testFolder);
         var filePath = filePath(folderPath);
         var fileContent = fileContent();
-        var provider = fileInfoProvider();
+        var provider = fileSystemHelper();
 
         // when
         // create folder
@@ -90,7 +82,7 @@ public class NioFileSystemHelperUnitTests {
         createFile(filePath, fileContent);
 
         // then
-        var fileInfo = provider.getFileInfos(folderPath).iterator().next();
+        var fileInfo = provider.getFileInfos(folderPath, xmlPathPredicate()).iterator().next();
         // verify path, creation and modification time
         assertEquals(filePath, fileInfo.filePath());
         assertEquals(getFileCreationTime(filePath), fileInfo.creationTime());
@@ -98,12 +90,12 @@ public class NioFileSystemHelperUnitTests {
     }
 
     @Test
-    public void givenProvider_whenModifyFile_thenGetFileInfo() throws InterruptedException {
+    public void givenFileSystemHelper_whenModifyFile_thenGetFileInfo() throws InterruptedException {
         // given
-        var folderPath = folderPath();
+        var folderPath = folderPath(testFolder);
         var filePath = filePath(folderPath);
         var fileContent = fileContent();
-        var provider = fileInfoProvider();
+        var provider = fileSystemHelper();
 
         // when
         // create folder
@@ -114,10 +106,50 @@ public class NioFileSystemHelperUnitTests {
         modifyFile(filePath, fileContentModified());
 
         // then
-        var fileInfo = provider.getFileInfos(folderPath).iterator().next();
+        var fileInfo = provider.getFileInfos(folderPath, xmlPathPredicate()).iterator().next();
         // verify path, creation and modification time
         assertEquals(filePath, fileInfo.filePath());
         assertEquals(getFileCreationTime(filePath), fileInfo.creationTime());
         assertEquals(getFileModificationTime(filePath), fileInfo.modificationTime());
+    }
+
+    @Test
+    public void givenFileSystemHelper_whenCreateNonXmlFile_thenDontGetFileInfo() throws InterruptedException {
+        // given
+        var folderPath = folderPath(testFolder);
+        var filePath = filePathNonXml(folderPath);
+        var fileContent = fileContent();
+        var provider = fileSystemHelper();
+
+        // when
+        // create folder
+        createFolder(folderPath);
+        // create XML file
+        createFile(filePath, fileContent);
+
+        // then
+        // verify empty result
+        assertEquals(0, provider.getFileInfos(folderPath, xmlPathPredicate()).size());
+    }
+
+    @Test
+    public void givenFileSystemHelper_whenModifyNonXmlFile_thenDontGetFileInfo() throws InterruptedException {
+        // given
+        var folderPath = folderPath(testFolder);
+        var filePath = filePathNonXml(folderPath);
+        var fileContent = fileContent();
+        var provider = fileSystemHelper();
+
+        // when
+        // create folder
+        createFolder(folderPath);
+        // create XML file
+        createFile(filePath, fileContent);
+        // modify XML file
+        modifyFile(filePath, fileContentModified());
+
+        // then
+        // verify empty result
+        assertEquals(0, provider.getFileInfos(folderPath, xmlPathPredicate()).size());
     }
 }

--- a/src/test/java/report/processor/util/TestUtils.java
+++ b/src/test/java/report/processor/util/TestUtils.java
@@ -7,10 +7,37 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
+import java.util.UUID;
 
 public class TestUtils {
-    public static final Path TEMP_FOLDER = Paths.get(System.getProperty("java.io.tmpdir"));
+    private static final Path TEMP_FOLDER = Paths.get(System.getProperty("java.io.tmpdir"));
+
+    public static Path folderPath() {
+        return TEMP_FOLDER.resolve(UUID.randomUUID().toString());
+    }
+
+    public static Path folderPath(Path parentFolderPath) {
+        return parentFolderPath.resolve(UUID.randomUUID().toString());
+    }
+
+    public static Path filePath(Path folderPath) {
+        return folderPath.resolve(UUID.randomUUID() + ".xml");
+    }
+
+    public static Path filePath(Path folderPath, String fileName) {
+        return folderPath.resolve(fileName + ".xml");
+    }
+
+    public static Path filePathNonXml(Path folderPath) {
+        return folderPath.resolve(UUID.randomUUID() + ".txt");
+    }
+
+    public static Path filePathXML(Path folderPath) {
+        return folderPath.resolve(UUID.randomUUID() + ".XML");
+    }
 
     public static void createFolder(Path folderPath) {
         try {
@@ -21,8 +48,8 @@ public class TestUtils {
     }
 
     public static void deleteFolder(Path folderPath) {
-        try {
-            Files.walk(folderPath)
+        try (var fileStream = Files.walk(folderPath)) {
+            fileStream
                     .sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
                     .forEach(File::delete);
@@ -55,6 +82,15 @@ public class TestUtils {
             var writer = new BufferedWriter(new FileWriter(filePath.toFile()));
             writer.write(content);
             writer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static FileTime getFileCreationTime(Path filePath) {
+        try {
+            var attr = Files.readAttributes(filePath, BasicFileAttributes.class);
+            return attr.creationTime();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
* move "folderPath" and "filePath" to TestUtils
* explicitly sync file creation threads in e2e test
* assert xmlParsingReportHandler3 in e2e test
* improve graceful and forced shutdown tests
* get rid of Thread.sleep(1)
* fix file descriptor leak in TestUtils.deleteFolder
* filter files in FileSystemHelper to only read attributes for XML files
* only call each handler once for each file change in ExecutorReportProcessor#submitFileChanges